### PR TITLE
Fix; Add support for extra droppable events

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Vue component of Shopify draggable.
 npm:
 
 ```bash
-npm install vue-shopify-draggable 
+npm install vue-shopify-draggable
 # peer dependencies
 npm install vue @shopify/draggable
 ```
@@ -211,7 +211,7 @@ Example
 <div id="VueEl"></div>
 
 <script type="text/template" id="VueTemplate">
-  <vue-droppable :options="options" @droppable:dropped="dropped">
+  <vue-droppable :options="options" @droppable:start="start" @droppable:dropped="dropped">
     <vue-draggable-container>
       <div class="dropzone draggable-dropzone--occupied"><div class="item">droppable-item1</div></div>
       <div class="dropzone draggable-dropzone--occupied"><div class="item">droppable-item2</div></div>
@@ -243,6 +243,9 @@ Example
     },
     methods: {
       dropped: function (e) {
+        console.log(e);
+      },
+      start: function (e) {
         console.log(e);
       },
     },

--- a/src/droppable/Droppable.js
+++ b/src/droppable/Droppable.js
@@ -1,7 +1,7 @@
 import { Droppable } from '@shopify/draggable';
 import draggableMixin from '../draggable-mixin';
 
-const events = ['droppable:dropped', 'droppable:returned'];
+const events = ['droppable:start', 'droppable:dropped', 'droppable:returned', 'droppable:stop'];
 
 export default {
   name: 'VueDroppable',

--- a/src/droppable/tests/Droppable.test.js
+++ b/src/droppable/tests/Droppable.test.js
@@ -44,6 +44,48 @@ describe('Droppable', () => {
   });
 
   describe('events', () => {
+    it('droppable:start', async () => {
+      const spy = jasmine.createSpy('droppable:start');
+      vueInstance = new Vue({
+        el,
+        template: `
+          <vue-droppable @droppable:start="func" :options="options" ref="droppable">
+            <vue-draggable-container>
+              <div class="dropzone draggable-dropzone--occupied" ref="dropzone1">
+                <div class="item" ref="item">
+                  draggable-source-1
+                </div>
+              </div>
+            </vue-draggable-container>
+            <vue-draggable-container>
+              <div class="dropzone" ref="dropzone2"></div>
+            </vue-draggable-container>
+          </vue-droppable>
+        `,
+        data() {
+          return {
+            options: {
+              draggable: '.item',
+              dropzone: '.dropzone',
+            },
+          };
+        },
+        methods: {
+          func(e) {
+            expect(e.constructor.name).toBe(Droppable.DroppableStartEvent.name);
+            spy();
+          },
+        },
+      });
+
+      await drag({
+        from: vueInstance.$refs.item,
+        to: vueInstance.$refs.dropzone2,
+      });
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
     it('droppable:dropped', async () => {
       const spy = jasmine.createSpy('droppable:dropped');
       vueInstance = new Vue({
@@ -126,6 +168,48 @@ describe('Droppable', () => {
       moveMouse(vueInstance.$refs.dropzone2, { pageY: 1, pageX: 0 });
       moveMouse(document.body, { pageY: 1, pageX: 0 });
       releaseMouse(document.body);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('droppable:stop', async () => {
+      const spy = jasmine.createSpy('droppable:stop');
+      vueInstance = new Vue({
+        el,
+        template: `
+          <vue-droppable @droppable:stop="func" :options="options" ref="droppable">
+            <vue-draggable-container>
+              <div class="dropzone draggable-dropzone--occupied" ref="dropzone1">
+                <div class="item" ref="item">
+                  draggable-source-1
+                </div>
+              </div>
+            </vue-draggable-container>
+            <vue-draggable-container>
+              <div class="dropzone" ref="dropzone2"></div>
+            </vue-draggable-container>
+          </vue-droppable>
+        `,
+        data() {
+          return {
+            options: {
+              draggable: '.item',
+              dropzone: '.dropzone',
+            },
+          };
+        },
+        methods: {
+          func(e) {
+            expect(e.constructor.name).toBe(Droppable.DroppableStopEvent.name);
+            spy();
+          },
+        },
+      });
+
+      await drag({
+        from: vueInstance.$refs.item,
+        to: vueInstance.$refs.dropzone2,
+      });
 
       expect(spy).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
Adds `droppable:start` and `droppable:stop` as per https://github.com/Shopify/draggable/tree/master/src/Droppable#events